### PR TITLE
chore: use HTTPS URL to clone repo

### DIFF
--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -113,7 +113,7 @@ jobs:
         run: pnpm run install:scripts
 
       - name: 🚀 Run specified benchmark
-        run: cd scripts && SPECIFIED_VERSION=${{ github.event.inputs.specifiedVersion }} ONLY_INSTALL_SIZE=${{ github.event.inputs.onlyInstallSize }} GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} COMMIT_ID=${{ github.event.inputs.commitId }} pnpm start ${{ matrix.product }} ${{ matrix.case }}
+        run: cd scripts && SPECIFIED_VERSION=${{ github.event.inputs.specifiedVersion }} ONLY_INSTALL_SIZE=${{ github.event.inputs.onlyInstallSize }} COMMIT_ID=${{ github.event.inputs.commitId }} pnpm start ${{ matrix.product }} ${{ matrix.case }}
 
       - name: Setup git user
         run: |

--- a/.github/workflows/pr-bench.yaml
+++ b/.github/workflows/pr-bench.yaml
@@ -81,7 +81,7 @@ jobs:
         run: pnpm run install:scripts
 
       - name: 🚀 Run specified benchmark
-        run: cd scripts && PR_NUMBER=${{ inputs.prNumber }} GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm start:pr ${{ inputs.product }}
+        run: cd scripts && PR_NUMBER=${{ inputs.prNumber }} pnpm start:pr ${{ inputs.product }}
 
       - id: print-results
         name: Print results

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -112,7 +112,7 @@ jobs:
         run: pnpm run install:scripts
 
       - name: 🚀 Run benchmark
-        run: cd scripts && GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm start ${{ matrix.product }} ${{ matrix.case }}
+        run: cd scripts && pnpm start ${{ matrix.product }} ${{ matrix.case }}
 
       - name: Setup git user
         run: |

--- a/scripts/src/shared/git.ts
+++ b/scripts/src/shared/git.ts
@@ -14,16 +14,14 @@ import { ROOT_PATH } from './constant';
 export async function cloneRepo(productName: string, caseName: string) {
   const repoName = getRepoName(productName);
   const localRepoPath = getRepoPath(repoName);
-  const { GITHUB_ACTOR, GITHUB_TOKEN, COMMIT_ID, PR_NUMBER } = process.env;
+  const { COMMIT_ID, PR_NUMBER } = process.env;
 
   if (PR_NUMBER) {
     await remove(localRepoPath);
   }
 
   if (!(await pathExists(localRepoPath))) {
-    const repoURL = GITHUB_TOKEN
-      ? `https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/web-infra-dev/${repoName}.git`
-      : `git@github.com:web-infra-dev/${repoName}.git`;
+    const repoURL = `https://github.com/web-infra-dev/${repoName}.git`;
 
     const options = ['clone'];
 


### PR DESCRIPTION
Use HTTPS URL to clone repo and no longer need to use `GITHUB_TOKEN`.