### PR TITLE
fix: support global virtual store in rsbuild-arco-pro

### DIFF
--- a/cases/rsbuild/rsbuild-arco-pro/package.json
+++ b/cases/rsbuild/rsbuild-arco-pro/package.json
@@ -12,7 +12,7 @@
     "@arco-design/web-react": "^2.66.16",
     "@arco-themes/react-arco-pro": "^0.0.7",
     "@loadable/component": "^5.16.7",
-    "@turf/turf": "^6.5.0",
+    "@turf/turf": "^7.4.0",
     "arco-design-pro": "^2.8.1",
     "axios": "^0.33.0",
     "bizcharts": "^4.1.23",

--- a/cases/rsbuild/rsbuild-arco-pro/rsbuild.config.js
+++ b/cases/rsbuild/rsbuild-arco-pro/rsbuild.config.js
@@ -5,6 +5,9 @@ import { pluginSvgr } from '@rsbuild/plugin-svgr';
 import { measurePlugin } from '@modern-js/benchmark-scripts/plugins/rsbuild';
 
 export default defineConfig({
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
   plugins: [
     pluginReact(),
     pluginLess(),


### PR DESCRIPTION
This PR makes the `rsbuild-arco-pro` benchmark compatible with pnpm's global virtual store. It upgrades `@turf/turf` to v7.4.0 and deduplicates `react` and `react-dom` so the case builds with a single React runtime.

## Related Links

- https://github.com/web-infra-dev/web-infra-QoS/actions/runs/33337051995/job/99325722090
- https://github.com/Turfjs/turf/releases/tag/v7.4.0